### PR TITLE
파일 업로드 구현 및 Coworker 프로필 이미지에 파일 업로드 API 적용

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -2,6 +2,9 @@
 /dist
 /node_modules
 
+# static files of current project directory
+/public/*
+
 # Logs
 logs
 *.log

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/mapped-types": "*",
         "@nestjs/passport": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
+        "@nestjs/serve-static": "^3.0.0",
         "@nestjs/swagger": "^6.1.3",
         "bcrypt": "^5.1.0",
         "class-transformer": "^0.5.1",
@@ -1810,6 +1811,23 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/@nestjs/serve-static": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-3.0.0.tgz",
+      "integrity": "sha512-TpXjgs4136dQqWUjEcONqppqXDsrJhRkmKWzuBMOUAnP4HjHpNmlycvkHnDnWSoG2YD4a7Enh4ViYGWqCfHStA==",
+      "dependencies": {
+        "path-to-regexp": "0.2.5"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0",
+        "@nestjs/core": "^9.0.0"
+      }
+    },
+    "node_modules/@nestjs/serve-static/node_modules/path-to-regexp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.5.tgz",
+      "integrity": "sha512-l6qtdDPIkmAmzEO6egquYDfqQGPMRNGjYtrU13HAXb3YSRrt7HSb1sJY0pKp6o2bAa86tSB6iwaW2JbthPKr7Q=="
     },
     "node_modules/@nestjs/swagger": {
       "version": "6.1.3",
@@ -11392,6 +11410,21 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
+        }
+      }
+    },
+    "@nestjs/serve-static": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-3.0.0.tgz",
+      "integrity": "sha512-TpXjgs4136dQqWUjEcONqppqXDsrJhRkmKWzuBMOUAnP4HjHpNmlycvkHnDnWSoG2YD4a7Enh4ViYGWqCfHStA==",
+      "requires": {
+        "path-to-regexp": "0.2.5"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.5.tgz",
+          "integrity": "sha512-l6qtdDPIkmAmzEO6egquYDfqQGPMRNGjYtrU13HAXb3YSRrt7HSb1sJY0pKp6o2bAa86tSB6iwaW2JbthPKr7Q=="
         }
       }
     },

--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/passport": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
+    "@nestjs/serve-static": "^3.0.0",
     "@nestjs/swagger": "^6.1.3",
     "bcrypt": "^5.1.0",
     "class-transformer": "^0.5.1",

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -51,6 +51,8 @@ model Coworker {
   devPart   DevPart
   projects  String[]
   coworkerWiki CoworkerWiki?
+  file File @relation(fields: [fileId], references: [id])
+  fileId Int @unique
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
@@ -73,6 +75,16 @@ model CoworkerWikiRevision {
   author User @relation(fields: [authorId], references: [id])
   authorId Int
   createdAt DateTime @default(now())
+}
+
+model File {
+  id Int @default(autoincrement()) @id
+  filename String
+  filePath String
+  fileSize Int
+  coworker Coworker?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 model Example {

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -51,8 +51,8 @@ model Coworker {
   devPart   DevPart
   projects  String[]
   coworkerWiki CoworkerWiki?
-  file File @relation(fields: [fileId], references: [id])
-  fileId Int @unique
+  file File? @relation(fields: [fileId], references: [id])
+  fileId Int? @unique
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
@@ -82,6 +82,7 @@ model File {
   filename String
   filePath String
   fileSize Int
+  mimeType String
   coworker Coworker?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -13,6 +13,9 @@ import { APP_GUARD } from '@nestjs/core';
 import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 import { CoworkerModule } from './coworker/coworker.module';
 import { ProjectModule } from './project/project.module';
+import { FileModule } from './file/file.module';
+import { ServeStaticModule } from '@nestjs/serve-static';
+import { join } from 'path';
 
 // 환경 변수 별 상수 설정
 let envFilename = '';
@@ -26,9 +29,15 @@ if (process.env.NODE_ENV === 'local') {
 
 @Module({
   imports: [
+    // .env 파일을 전역적으로 사용할 수 있도록 적용한다.
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: envFilename,
+    }),
+    // 정적 파일을 /statics 라우트로 제공한다.
+    ServeStaticModule.forRoot({
+      rootPath: join(__dirname, '..', 'public'),
+      serveRoot: '/statics',
     }),
     ExampleModule,
     UserModule,
@@ -38,6 +47,7 @@ if (process.env.NODE_ENV === 'local') {
     PrismaModule,
     CoworkerModule,
     ProjectModule,
+    FileModule,
   ],
   controllers: [AppController],
   providers: [
@@ -49,4 +59,5 @@ if (process.env.NODE_ENV === 'local') {
     },
   ],
 })
-export class AppModule {}
+export class AppModule {
+}

--- a/server/src/common/enums/bbs-type.enum.ts
+++ b/server/src/common/enums/bbs-type.enum.ts
@@ -1,0 +1,3 @@
+export enum BbsType {
+  COWORKER = 'Coworker',
+}

--- a/server/src/common/lib/multer.option.ts
+++ b/server/src/common/lib/multer.option.ts
@@ -5,6 +5,7 @@ import { existsSync, mkdirSync } from 'fs';
 import { randomUUID } from 'crypto';
 
 export const multerOptions: MulterOptions = {
+  // 파일에 대한 유효성을 검증한다.
   fileFilter: (request, file, callback) => {
     if (file.mimetype.match(/\/(jpg|jpeg|png)$/)) {
       callback(null, true);
@@ -13,6 +14,9 @@ export const multerOptions: MulterOptions = {
     }
   },
 
+  // 현 프로젝트의 public 디렉토리에 파일을 저장한다.
+  // 만일, 해당 경로에 해당하는 디렉토리가 존재하지 않을 경우 새로 생성한다.
+  // 파일명은 무작위 UUID + 기존 파일명이다.
   storage: diskStorage({
     destination: (request, file, callback) => {
       const uploadPath = 'public';

--- a/server/src/common/lib/multer.option.ts
+++ b/server/src/common/lib/multer.option.ts
@@ -1,0 +1,34 @@
+import { MulterOptions } from '@nestjs/platform-express/multer/interfaces/multer-options.interface';
+import { BadRequestException } from '@nestjs/common';
+import { diskStorage } from 'multer';
+import { existsSync, mkdirSync } from 'fs';
+import { randomUUID } from 'crypto';
+
+export const multerOptions: MulterOptions = {
+  fileFilter: (request, file, callback) => {
+    if (file.mimetype.match(/\/(jpg|jpeg|png)$/)) {
+      callback(null, true);
+    } else {
+      callback(new BadRequestException('지원하지 않는 파일 형식입니다. currentType=' + file.mimetype), false);
+    }
+  },
+
+  storage: diskStorage({
+    destination: (request, file, callback) => {
+      const uploadPath = 'public';
+
+      if (!existsSync(uploadPath)) {
+        mkdirSync(uploadPath);
+      }
+
+      callback(null, uploadPath);
+    },
+    filename: (req, file, callback) => {
+      callback(null, randomUUID() + file.originalname);
+    },
+  }),
+};
+//
+// export const createdFileUrl = (file): string => {
+//   const serverAddr: string = getP
+// }

--- a/server/src/coworker/coworker.controller.ts
+++ b/server/src/coworker/coworker.controller.ts
@@ -1,18 +1,4 @@
-import {
-  Body,
-  Controller,
-  Delete,
-  FileTypeValidator,
-  Get,
-  MaxFileSizeValidator,
-  Param,
-  ParseFilePipe,
-  Patch,
-  Post,
-  Req,
-  UploadedFile,
-  UseInterceptors,
-} from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Req } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiBearerAuth,
@@ -31,7 +17,6 @@ import { CreateCoworkerWikiDto } from './dto/request/create-coworker-wiki.dto';
 import { CoworkerWikiResponseDto } from './dto/response/coworker-wiki-response.dto';
 import { Request } from 'express';
 import { CoworkerWikiRevisionResponseDto } from './dto/response/coworker-wiki-revision-response.dto';
-import { FileInterceptor } from '@nestjs/platform-express';
 
 @ApiTags('함께한 개발자 API')
 @Controller('coworker')
@@ -49,20 +34,9 @@ export class CoworkerController {
     type: CoworkerResponseDto,
   })
   @ApiBadRequestResponse({ description: '생성 실패 - 중복된 개발자' })
-  @UseInterceptors(FileInterceptor('profileImage'))
-  async create(
-    @Body() requestDto: CreateCoworkerDto,
-    @UploadedFile(
-      new ParseFilePipe({
-        validators: [
-          new MaxFileSizeValidator({ maxSize: 3000 }),
-          new FileTypeValidator({ fileType: /\.(gif|jpe?g|tiff?|png|webp|bmp)$/i }),
-        ],
-      }),
-    )
-    profileImage: Express.Multer.File,
-  ): Promise<CoworkerResponseDto> {
-    return this.coworkerService.create(requestDto, profileImage);
+  async create(@Body() requestDto: CreateCoworkerDto): Promise<CoworkerResponseDto> {
+    console.log(requestDto);
+    return this.coworkerService.create(requestDto);
   }
 
   @ApiBearerAuth(HttpHeaders.AUTHORIZATION)
@@ -149,14 +123,16 @@ export class CoworkerController {
     });
   }
 
-  // TODO: 개발할 것.
   @ApiBearerAuth(HttpHeaders.AUTHORIZATION)
   @Get('wiki/:coworkerId')
   @ApiOperation({
     summary: '특정 개발자 위키 조회 API',
     description: '개발자의 시퀀스를 Path Var 로 전달받아 해당하는 개발자의 위키를 조회한다.',
   })
-  @ApiOkResponse({ description: '조회 성공', type: CoworkerWikiResponseDto })
+  @ApiOkResponse({
+    description: '조회 성공',
+    type: CoworkerWikiResponseDto,
+  })
   @ApiNotFoundResponse({ description: '조회 실패 - 시퀀스 미조회' })
   async findWikiOfSpecificCoworker(@Param('coworkerId') coworkerId: number): Promise<CoworkerWikiResponseDto> {
     return this.coworkerService.findWikiOfSpecificCoworker(coworkerId);

--- a/server/src/coworker/coworker.controller.ts
+++ b/server/src/coworker/coworker.controller.ts
@@ -26,8 +26,8 @@ export class CoworkerController {
   @ApiBearerAuth(HttpHeaders.AUTHORIZATION)
   @Post()
   @ApiOperation({
-    summary: '생성 API',
-    description: '함께한 개발자 데이터를 생성한다.',
+    summary: '생성 API - File(Optional)',
+    description: '함께한 개발자 데이터를 생성한다. 개발자의 프로필 이미지는 파일 업로드 API 를 활용한다.',
   })
   @ApiCreatedResponse({
     description: '생성 성공',

--- a/server/src/coworker/coworker.service.ts
+++ b/server/src/coworker/coworker.service.ts
@@ -14,10 +14,7 @@ export class CoworkerService {
    * @param coworkerCreateInput 요청 전문
    * @return 유저 응답 DTO
    */
-  async create(
-    coworkerCreateInput: Prisma.CoworkerCreateInput,
-    profileImage: Express.Multer.File,
-  ): Promise<CoworkerResponseDto> {
+  async create(coworkerCreateInput: Prisma.CoworkerCreateInput): Promise<CoworkerResponseDto> {
     const { ...data } = coworkerCreateInput;
 
     if (!Object.values(DevPart).includes(data.devPart)) {
@@ -136,7 +133,10 @@ export class CoworkerService {
   async findAllRevisionOfSpecificCoworker(coworkerWikiId: number) {
     const wikiRevisions: Array<any> = await this.prismaService.coworkerWikiRevision.findMany({
       where: { coworkerWikiId: coworkerWikiId },
-      include: { coworkerWiki: true, author: true },
+      include: {
+        coworkerWiki: true,
+        author: true,
+      },
     });
 
     return wikiRevisions.map((eachEntity) => new CoworkerWikiRevisionResponseDto(eachEntity));

--- a/server/src/file/dto/response/file-response.dto.ts
+++ b/server/src/file/dto/response/file-response.dto.ts
@@ -1,9 +1,44 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { File as FileModel } from '@prisma/client';
+import { TimeUtils } from '../../../common/utils/time.util';
 
 export class FileResponseDto {
+  constructor(file: FileModel) {
+    if (file) {
+      this.id = file.id;
+      this.filename = file.filename;
+      this.filePath = file.filePath;
+      this.fileSize = file.fileSize;
+      this.mimeType = file.mimeType;
+      this.createdAt = TimeUtils.convertDateToLocalDateTimeStr(file.createdAt);
+      this.updatedAt = TimeUtils.convertDateToLocalDateTimeStr(file.updatedAt);
+    }
+  }
+
+  @ApiProperty({ description: '파일 시퀀스' })
+  readonly id: number;
+
   @ApiProperty({ description: '파일명' })
   readonly filename: string;
 
   @ApiProperty({ description: '파일 저장 경로' })
   readonly filePath: string;
+
+  @ApiProperty({ description: '파일 사이즈' })
+  readonly fileSize: number;
+
+  @ApiProperty({ description: '파일 타입' })
+  readonly mimeType: string;
+
+  @ApiProperty({
+    description: '생성일',
+    example: '2022-01-01 00:00:00',
+  })
+  readonly createdAt: string;
+
+  @ApiProperty({
+    description: '수정일',
+    example: '2022-01-01 00:00:00',
+  })
+  readonly updatedAt: string;
 }

--- a/server/src/file/dto/response/file-response.dto.ts
+++ b/server/src/file/dto/response/file-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FileResponseDto {
+  @ApiProperty({ description: '파일명' })
+  readonly filename: string;
+
+  @ApiProperty({ description: '파일 저장 경로' })
+  readonly filePath: string;
+}

--- a/server/src/file/file.controller.spec.ts
+++ b/server/src/file/file.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FileController } from './file.controller';
+import { FileService } from './file.service';
+
+describe('FileController', () => {
+  let controller: FileController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FileController],
+      providers: [FileService],
+    }).compile();
+
+    controller = module.get<FileController>(FileController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/file/file.controller.ts
+++ b/server/src/file/file.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { FileService } from './file.service';
+import { ApiBearerAuth, ApiBody, ApiConsumes, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { HttpHeaders } from '../common/enums/http-headers.enum';
+import { multerOptions } from '../common/lib/multer.option';
+
+@ApiTags('파일 API')
+@Controller('file')
+export class FileController {
+  constructor(private readonly fileService: FileService) {}
+
+  @ApiBearerAuth(HttpHeaders.AUTHORIZATION)
+  @Post('upload/:bbsType/:bbsId')
+  @ApiOperation({
+    summary: '파일 단일 업로드 API',
+    description: 'Multipart/form-data 로 데이터를 전달받아 파일을 업로드한다.',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  })
+  @UseInterceptors(FileInterceptor('file', multerOptions))
+  async uploadFile(@UploadedFile() file: Express.Multer.File) {
+    const { filename, path, size } = file;
+    await this.fileService.uploadFile({
+      filename: filename,
+      filePath: path,
+      fileSize: size,
+    });
+  }
+}

--- a/server/src/file/file.controller.ts
+++ b/server/src/file/file.controller.ts
@@ -1,9 +1,12 @@
-import { Controller, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { BadRequestException, Controller, Param, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
 import { FileService } from './file.service';
-import { ApiBearerAuth, ApiBody, ApiConsumes, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiConsumes, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { HttpHeaders } from '../common/enums/http-headers.enum';
 import { multerOptions } from '../common/lib/multer.option';
+import { BbsType } from '../common/enums/bbs-type.enum';
+import { Prisma } from '@prisma/client';
+import { FileResponseDto } from './dto/response/file-response.dto';
 
 @ApiTags('파일 API')
 @Controller('file')
@@ -28,13 +31,37 @@ export class FileController {
       },
     },
   })
-  @UseInterceptors(FileInterceptor('file', multerOptions))
-  async uploadFile(@UploadedFile() file: Express.Multer.File) {
-    const { filename, path, size } = file;
-    await this.fileService.uploadFile({
+  @ApiParam({
+    name: 'bbsType',
+    required: true,
+    enum: BbsType,
+  })
+  @UseInterceptors(FileInterceptor('file', multerOptions)) // Multer Option 을 활용한 서버 프로젝트 내 파일 업로드
+  async uploadFile(
+    @Param('bbsType') bbsType: BbsType,
+    @Param('bbsId') bbsId: number,
+    @UploadedFile() file: Express.Multer.File,
+  ): Promise<FileResponseDto> {
+    const { filename, path, size, mimetype } = file;
+
+    const fileCreateInput: Prisma.FileCreateInput = {
       filename: filename,
       filePath: path,
       fileSize: size,
-    });
+      mimeType: mimetype,
+    };
+
+    // bbsType 을 체크한다.
+    switch (bbsType) {
+      case BbsType.COWORKER:
+        fileCreateInput.coworker = {
+          connect: { id: bbsId },
+        };
+        break;
+      default:
+        throw new BadRequestException('일치하는 bbsType 을 찾을 수 없습니다. bbsType=' + bbsType);
+    }
+
+    return this.fileService.uploadFile(fileCreateInput);
   }
 }

--- a/server/src/file/file.module.ts
+++ b/server/src/file/file.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { FileService } from './file.service';
+import { FileController } from './file.controller';
+
+@Module({
+  controllers: [FileController],
+  providers: [FileService]
+})
+export class FileModule {}

--- a/server/src/file/file.service.spec.ts
+++ b/server/src/file/file.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FileService } from './file.service';
+
+describe('FileService', () => {
+  let service: FileService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FileService],
+    }).compile();
+
+    service = module.get<FileService>(FileService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/file/file.service.ts
+++ b/server/src/file/file.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../common/prisma/prisma.service';
-import { Prisma } from '@prisma/client'
+import { Prisma, File as FileModel } from '@prisma/client';
+import { FileResponseDto } from './dto/response/file-response.dto';
 
 @Injectable()
 export class FileService {
@@ -8,14 +9,12 @@ export class FileService {
 
   /**
    * 서버 단에 저장된 파일을 데이터베이스에 관련 정보를 저장한다.
-   * @param file
+   * @param fileCreateInput 파일 메타데이터에 대한 프리즈마 DTO
    * @return 저장된 파일에 대한 DTO
    */
-  async uploadFile(fileCreateInput: Prisma.FileCreateInput) {
-    await this.prismaService.file.create({
-      data: {
+  async uploadFile(fileCreateInput: Prisma.FileCreateInput): Promise<FileResponseDto> {
+    const fileEntity: FileModel = await this.prismaService.file.create({ data: fileCreateInput });
 
-      }
-    })
+    return new FileResponseDto(fileEntity);
   }
 }

--- a/server/src/file/file.service.ts
+++ b/server/src/file/file.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../common/prisma/prisma.service';
+import { Prisma } from '@prisma/client'
+
+@Injectable()
+export class FileService {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  /**
+   * 서버 단에 저장된 파일을 데이터베이스에 관련 정보를 저장한다.
+   * @param file
+   * @return 저장된 파일에 대한 DTO
+   */
+  async uploadFile(fileCreateInput: Prisma.FileCreateInput) {
+    await this.prismaService.file.create({
+      data: {
+
+      }
+    })
+  }
+}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -9,10 +9,15 @@ import { HttpHeaders } from './common/enums/http-headers.enum';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // 역직렬화 적용 (TypeORM 기반 DTO toEntity 에서 유효)
   app.useGlobalPipes(new ValidationPipe({ transform: true }));
+
+  // 커스텀 공통 Response Interceptor 및 공통 예외 처리 필터 적용
   app.useGlobalInterceptors(new ResponseInterceptor());
   app.useGlobalFilters(new HttpExceptionFilter());
 
+  // 프리즈마 서비스 전역 적용
   const prismaService = app.get(PrismaService);
   await prismaService.enableShutdownHooks(app);
 


### PR DESCRIPTION
- 추후 파일 업로드 시, 파일 단일 파일 업로드 API 내 기존 실제 파일 제거 및 데이터베이스에서 제거한 후, 새로운 파일이 덮어씌워지도록 수정해야 함.

- 파일 삭제 API 구현 및 다중 파일 업로드, 다중 파일 제거 API 구현 필요함.