### PR TITLE
[#36 Issue Resolved] Viewer 단 목차 하이퍼링크 미동작 해결

### DIFF
--- a/web/components/inputs/tui-viewer.tsx
+++ b/web/components/inputs/tui-viewer.tsx
@@ -2,14 +2,26 @@ import "@toast-ui/editor/dist/toastui-editor.css";
 
 import { Viewer } from '@toast-ui/react-editor';
 import { NextPage } from 'next';
-import { useEffect, useState } from 'react';
 
 interface Props {
   initMarkdown?: string;
 }
 
 const TuiViewer: NextPage<Props> = ({ initMarkdown }) => {
-  return <Viewer initialValue={ initMarkdown ? initMarkdown : '' }  />
+  return <Viewer
+    initialValue={ initMarkdown ? initMarkdown : '' }
+    customHTMLRenderer={{
+      heading(node: any, ctx: any) {
+        return {
+          type: ctx.entering ? 'openTag' : 'closeTag',
+          tagName: `h${node.level}`,
+          attributes: {
+            id: node.firstChild?.literal.replace(' ', '-')
+          }
+        };
+      },
+    }}
+  />
 }
 
 export default TuiViewer;


### PR DESCRIPTION
- Viewer 컴포넌트 내 customHTMLRenderer Props 에서, 마크다운 heading 태그 존재 시, HTML 렌더링 전 헤더의 이름에 해당하는 ID 로 지정하여 해결. 