### PR TITLE
[#66 Issue Resolved] Coworker 프로필 사진 미 업로드 시, 수정 화면에서 500 에러 발생 해결

### DIFF
--- a/web/pages/people/[coworkerId].tsx
+++ b/web/pages/people/[coworkerId].tsx
@@ -140,7 +140,7 @@ export const PeopleUpdate: NextPage<Props> = ({ coworkerId }) => {
   };
 
   // 파일 메소드
-  const [imageUrl, setImageUrl] = useState<any>("");
+  const [imageUrl, setImageUrl] = useState<any>();
   const imgRef = useRef<any>();
 
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -253,7 +253,7 @@ export const PeopleUpdate: NextPage<Props> = ({ coworkerId }) => {
           }
         });
         setProjectTag([...projectTagList])
-        setImageUrl(`${response.data.data.profileImage.filePath}`);
+        setImageUrl(response.data.data.profileImage.filePath);
       } catch (err) {
         console.log(err);
       }


### PR DESCRIPTION
useEffect 내 profileImage 가 undefined 였을 때, 스트링으로 묶어서 setState 하고 있었음. 