### PR TITLE
[#79 Issue Resolved] 크롬 브라우저 내 scrollToTop 이슈

### DIFF
--- a/web/components/buttons/btn-scroll-to-top.tsx
+++ b/web/components/buttons/btn-scroll-to-top.tsx
@@ -2,10 +2,7 @@ import { AiOutlineArrowUp } from "react-icons/ai";
 
 export const BtnScrollToTop = () => {
   const scrollToTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: "smooth"
-    })
+    window.scrollTo(0, 0);
   }
 
   return (


### PR DESCRIPTION
- scrollToTop 내 로직의 `window.scrollTo()` 의 인자로 옵션 대신 `x, y` 값을 0으로 지정함.